### PR TITLE
fix: #42 現状の方法だと隠匿化を破られる可能性があるため、apikeyの隠し方をInfo.plistからConstants.swi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ iOSInjectionProject/
 
 
 GitHubSearch/Info.plist
+GitHubSearch/Constants.swift

--- a/GitHubSearch.xcodeproj/project.pbxproj
+++ b/GitHubSearch.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		D692FAD22AE7BFC100856363 /* MockRepoAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D692FAD12AE7BFC100856363 /* MockRepoAPIClient.swift */; };
 		D692FAD42AE7D8AF00856363 /* StubRepositoryFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D692FAD32AE7D8AF00856363 /* StubRepositoryFetcher.swift */; };
 		D6ABDEA22AAD9E5F004E1BA4 /* RepositoryViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6ABDEA12AAD9E5F004E1BA4 /* RepositoryViewModelTest.swift */; };
+		D6AE199F2B2DDB5E0048A033 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6AE199E2B2DDB5E0048A033 /* Constants.swift */; };
 		D6E4999B2A51B896007F9FB0 /* GitHubSearchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E4999A2A51B896007F9FB0 /* GitHubSearchApp.swift */; };
 		D6E4999D2A51B896007F9FB0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E4999C2A51B896007F9FB0 /* ContentView.swift */; };
 		D6E4999F2A51B897007F9FB0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D6E4999E2A51B897007F9FB0 /* Assets.xcassets */; };
@@ -49,6 +50,7 @@
 		D692FAD12AE7BFC100856363 /* MockRepoAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRepoAPIClient.swift; sourceTree = "<group>"; };
 		D692FAD32AE7D8AF00856363 /* StubRepositoryFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubRepositoryFetcher.swift; sourceTree = "<group>"; };
 		D6ABDEA12AAD9E5F004E1BA4 /* RepositoryViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryViewModelTest.swift; sourceTree = "<group>"; };
+		D6AE199E2B2DDB5E0048A033 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		D6B53A532A618D3D00258B3F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D6E499972A51B896007F9FB0 /* GitHubSearch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GitHubSearch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D6E4999A2A51B896007F9FB0 /* GitHubSearchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearchApp.swift; sourceTree = "<group>"; };
@@ -139,6 +141,7 @@
 			children = (
 				D6B53A532A618D3D00258B3F /* Info.plist */,
 				D6E4999A2A51B896007F9FB0 /* GitHubSearchApp.swift */,
+				D6AE199E2B2DDB5E0048A033 /* Constants.swift */,
 				D6ED92812AA6BB2D00D84517 /* Common */,
 				D6ABDE9E2AAC926A004E1BA4 /* Entity */,
 				D6E499C42A523CF0007F9FB0 /* Models */,
@@ -357,6 +360,7 @@
 				D6E499CC2A5244B7007F9FB0 /* APIurl.swift in Sources */,
 				D6E4999B2A51B896007F9FB0 /* GitHubSearchApp.swift in Sources */,
 				D6E499CE2A5244C9007F9FB0 /* APIError.swift in Sources */,
+				D6AE199F2B2DDB5E0048A033 /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GitHubSearch/Constants.swift
+++ b/GitHubSearch/Constants.swift
@@ -1,0 +1,12 @@
+//
+//  Constants.swift
+//  GitHubSearch
+//
+//  Created by Ryuga on 2023/12/16.
+//
+
+import Foundation
+
+struct Constants {
+    static let apiKey = "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"
+}

--- a/GitHubSearch/Models/GitHubAPIClient.swift
+++ b/GitHubSearch/Models/GitHubAPIClient.swift
@@ -17,7 +17,7 @@ final class GitHubAPIClient: GitHubAPIClientInterface {
 
         // URLRequestを作成
         var request = URLRequest(url: url)
-        request.setValue("Bearer API_KEY", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(Constants.apiKey)", forHTTPHeaderField: "Authorization")
 
         // URLSessionでRequest
         let (data, response) = try await URLSession.shared.data(from: url)


### PR DESCRIPTION
…ftに記載し、.gitignoreで隠す方法に修正した。